### PR TITLE
RIL subclasses: Fix processSolicited for the new API

### DIFF
--- a/ril/telephony/java/com/android/internal/telephony/X3RIL.java
+++ b/ril/telephony/java/com/android/internal/telephony/X3RIL.java
@@ -168,7 +168,7 @@ public class X3RIL extends RIL implements CommandsInterface {
             p.setDataPosition(dataPosition);
 
             // Forward responses that we are not overriding to the super class
-            return super.processSolicited(p);
+            super.processSolicited(p);
         }
 
 


### PR DESCRIPTION
Obviously based on the work by rmcc: https://github.com/CyanogenMod/android_frameworks_opt_telephony/commit/603113fa8177fa29a2f42982dffd0e48e8b4d9ba

It needs to un-comment the lines in BoardConfig.mk and in system.prop.
Then, please, revert: https://github.com/P880-dev/android_device_lge_p880/commit/9532b2b400752831736362077a1af19b26f1849d
