### PR TITLE
fix wifi (tested & working)

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -58,7 +58,7 @@ BOARD_HOSTAPD_DRIVER        := NL80211
 BOARD_HOSTAPD_PRIVATE_LIB   := lib_driver_cmd_bcmdhd
 WIFI_DRIVER_FW_PATH_PARAM   := "/sys/module/bcmdhd/parameters/firmware_path"
 WIFI_DRIVER_FW_PATH_STA     := "/system/etc/firmware/fw_bcmdhd.bin"
-WIFI_DRIVER_FW_PATH_P2P     := "/system/etc/firmware/fw_bcmdhd.bin"
+WIFI_DRIVER_FW_PATH_P2P     := "/system/etc/firmware/fw_bcmdhd_p2p.bin"
 WIFI_DRIVER_FW_PATH_AP      := "/system/etc/firmware/fw_bcmdhd_apsta.bin"
 
 TARGET_BOOTANIMATION_PRELOAD := true


### PR DESCRIPTION
IMPORTANT:
add these missing blobs in vendor/lge/p880/proprietary/etc/firmware:
- fw_bcmdhd.bin
- fw_bcmdhd_p2p.bin (its really needed beleive me)
- fw_bcmdhd_apsta.bin
  --> (https://github.com/laufersteppenwolf/vendor_lge_p880/tree/master/proprietary/etc/firmware)

of course you additionally have to replace them in "p880-vendor-blobs.mk":
(delete hardware/broadcom.....)
- vendor/lge/p880/proprietary/etc/firmware/fw_bcmdhd.bin:system/etc/firmware/fw_bcmdhd.bin \
  vendor/lge/p880/proprietary/etc/firmware/fw_bcmdhd_p2p.bin:system/etc/firmware/fw_bcmdhd_p2p.bin \
  vendor/lge/p880/proprietary/etc/firmware/fw_bcmdhd_apsta.bin:system/etc/firmware/fw_bcmdhd_apsta.bin \

INFO:
The from hardware/broadcom used drivers for Wifi definetly arent working with our device. So use this and please finally beleive me :D

If you test it in a prebuild Build its very important to delete "out/target/product/p880/system/firmware/etc/firmware/" that the drivers will be renewed.

Climes
